### PR TITLE
fix(cucumber): Support callback style step definitions (fixes #8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "graceful-fs": "4.1.4",
+    "is-generator": "1.0.3",
     "lodash": "4.13.1",
     "mkdirp": "0.5.1",
     "moment": "2.14.1",


### PR DESCRIPTION
Match syncronized steps with the contract cucumber expects. es6 generators accepted by cucumber are still not supported (#9)