### PR TITLE
Fix coverage reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,12 +122,15 @@
     "exclude": [
       "spec",
       "examples/**",
-      "node_modules"
+      "node_modules",
+      "typings"
     ],
     "extension": [
       ".ts"
     ],
-    "require": [],
+    "require": [
+      "ts-node/register"
+    ],
     "reporter": [
       "json",
       "text-summary"

--- a/spec/mocha.opts
+++ b/spec/mocha.opts
@@ -1,2 +1,2 @@
---require ./spec/transpiler
+--compilers ts:ts-node/register --lazy
 --reporter spec

--- a/spec/transpiler.js
+++ b/spec/transpiler.js
@@ -1,7 +1,0 @@
-var path = require('path');
-
-require('ts-node').register({
-    lazy:    true,
-    fast:    false,
-    project: path.resolve(__dirname, '../')
-});


### PR DESCRIPTION
Istanbul wasn't instrumenting properly files not required by specs and they were omitted in coverage reports.
[webdriver_synchroniser.ts](https://github.com/jan-molak/serenity-js/blob/master/src/serenity-cucumber/webdriver_synchroniser.ts) for instance.

Also now I know that webdriver_synchroniser is not plugged into cucumber integration tests and will fix it with next PR.