### PR TITLE
fix(node version): update the node version with >= 6.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "url": "https://github.com/jan-molak/serenity-js/issues"
   },
   "engines": {
-    "node": "6.9.x",
+    "node": ">= 6.9.x",
     "npm": ">= 3"
   },
   "config": {

--- a/packages/serenity-js.cucumber-2/package.json
+++ b/packages/serenity-js.cucumber-2/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/jan-molak/serenity-js/issues"
   },
   "engines": {
-    "node": "6.9.x",
+    "node": ">= 6.9.x",
     "npm": ">= 3"
   },
   "devDependencies": {

--- a/packages/serenity-js/package.json
+++ b/packages/serenity-js/package.json
@@ -84,7 +84,7 @@
     "url": "https://github.com/jan-molak/serenity-js/issues"
   },
   "engines": {
-    "node": "6.9.x",
+    "node": ">= 6.9.x",
     "npm": ">= 3"
   },
   "nyc": {


### PR DESCRIPTION
Update the node version of package.json with >= 6.9.0.
It will make the Serenity JS work with the last node v6.10.0.

affects: serenity-js.cucumber-2, serenity-js