### PR TITLE
#159 feat: add ConditionalPerformable to permit flow control

### DIFF
--- a/packages/core/src/screenplay/conditionals.ts
+++ b/packages/core/src/screenplay/conditionals.ts
@@ -1,0 +1,102 @@
+import { Activity, Interaction } from './activities';
+import { Actor, AnswersQuestions, PerformsTasks, UsesAbilities } from './actor';
+import { Question } from './question';
+
+export class SilentPerformable implements Interaction {
+    performAs(actor: PerformsTasks | UsesAbilities | AnswersQuestions): PromiseLike<void> {
+        return undefined;
+    }
+}
+
+export abstract class ConditionalPerformable implements Activity {
+
+    protected outcomeToPerform: { [key: string]: Activity[]; } = {};
+
+    constructor() {
+        this.outcomeToPerform['true'] = [new SilentPerformable()];
+        this.outcomeToPerform['false'] = [new SilentPerformable()];
+    }
+
+    andIfSo = (...activities: Activity[]) => {
+        this.outcomeToPerform['true'] = activities;
+        return this;
+    }
+
+    otherwise = (...activities: Activity[]) => {
+        this.outcomeToPerform['false'] = activities;
+        return this;
+    }
+
+    abstract evaluatedConditionFor(actor: PerformsTasks): boolean;
+
+    performAs(actor: PerformsTasks): PromiseLike<void> {
+        return actor.attemptsTo(...this.outcomeToPerform[this.evaluatedConditionFor(actor).toString()]);
+    };
+}
+
+export abstract class ConditionalPerformablePromise implements Activity {
+
+    protected outcomeToPerform: { [key: string]: Activity[]; } = {};
+
+    constructor() {
+        this.outcomeToPerform['true'] = [new SilentPerformable()];
+        this.outcomeToPerform['false'] = [new SilentPerformable()];
+    }
+
+    andIfSo = (...activities: Activity[]) => {
+        this.outcomeToPerform['true'] = activities;
+        return this;
+    }
+
+    otherwise = (...activities: Activity[]) => {
+        this.outcomeToPerform['false'] = activities;
+        return this;
+    }
+
+    abstract evaluatedConditionFor(actor: PerformsTasks): PromiseLike<boolean>;
+
+    performAs(actor: PerformsTasks): PromiseLike<void> {
+        return this.evaluatedConditionFor(actor).then(value => actor.attemptsTo(...this.outcomeToPerform[value.toString()]));
+    };
+}
+
+class ConditionalPerformableOnBoolean extends ConditionalPerformable {
+
+    constructor(private condition: boolean) {
+        super();
+    };
+
+    evaluatedConditionFor(actor: Actor) {
+        return this.condition;
+    };
+}
+
+class ConditionalPerformableOnQuestion extends ConditionalPerformable {
+
+    constructor(private condition: Question<boolean>) {
+        super();
+    };
+
+    evaluatedConditionFor(actor: Actor) {
+        return this.condition.answeredBy(actor);
+    };
+
+}
+
+class ConditionalPerformableOnQuestionPromise extends ConditionalPerformablePromise {
+
+    constructor(private condition: Question<PromiseLike<boolean>>) {
+        super();
+    };
+
+    evaluatedConditionFor(actor: Actor) {
+        return this.condition.answeredBy(actor);
+    };
+
+}
+
+export class Check {
+    static whether = (condition: boolean): ConditionalPerformable => new ConditionalPerformableOnBoolean(condition);
+    static whetherQuestionTrue = (condition: Question<boolean>): ConditionalPerformable => new ConditionalPerformableOnQuestion(condition);
+    static whetherPromiseTrue = (condition: Question<PromiseLike<boolean>>): ConditionalPerformablePromise => new ConditionalPerformableOnQuestionPromise(condition);
+}

--- a/packages/core/src/screenplay/index.ts
+++ b/packages/core/src/screenplay/index.ts
@@ -1,5 +1,6 @@
 export * from './abilities';
 export * from './activities';
 export * from './actor';
+export * from './conditionals';
 export * from './interactions';
 export * from './question';

--- a/packages/serenity-js/spec/cookbook/conditionals.recipe.ts
+++ b/packages/serenity-js/spec/cookbook/conditionals.recipe.ts
@@ -1,0 +1,193 @@
+import { Actor } from '@serenity-js/core/lib/screenplay';
+import * as webdriver from 'selenium-webdriver';
+
+import sinon = require('sinon');
+import expect = require('../expect');
+
+import { UsesAbilities } from '../../../core/lib/screenplay/actor';
+import { Check } from '../../../core/src/screenplay/conditionals';
+import { Question } from '../../../core/src/screenplay/question';
+import { BrowseTheWeb, Click, Target } from '../../src/serenity-protractor/screenplay';
+import { Enter } from '../../src/serenity-protractor/screenplay/interactions/enter';
+import { fakeBrowserLocating } from '../api/serenity-protractor/screenplay/interactions/fake_browser';
+
+describe('The conditional performable', () => {
+
+    describe('when used with boolean argument', () => {
+        const inputField = Target.the('Input field').located(webdriver.By.css('button#wahoo'));
+
+        it('triggers tasks in the andIfSo() argument when the boolean condition is true', () => {
+            const
+                element = sinon.createStubInstance(webdriver.WebElement) as any,
+                actor = Actor.named('Nick').whoCan(BrowseTheWeb.using(fakeBrowserLocating(element)));
+
+            element.click.returns(Promise.resolve());
+
+            const promise = actor.attemptsTo(
+                Check.whether(true)
+                    .andIfSo(
+                        Enter.theValue('Yay!').into(inputField),
+                        Enter.theValue('Yay!').into(inputField),
+                        Enter.theValue('Yay!').into(inputField))
+                    .otherwise(
+                        Enter.theValue('Noooo :-(').into(inputField),
+                        Enter.theValue('Noooo :-(').into(inputField),
+                        Enter.theValue('Noooo :-(').into(inputField)),
+            );
+
+            return expect(promise).to.be.eventually.fulfilled.then(() => {
+                expect(element.sendKeys).to.have.been.calledWith('Yay!').callCount(3);
+            });
+
+        });
+
+        it('triggers tasks in the otherwise() argument when the boolean condition is false', () => {
+            const
+                element = sinon.createStubInstance(webdriver.WebElement) as any,
+                actor = Actor.named('Nick').whoCan(BrowseTheWeb.using(fakeBrowserLocating(element)));
+
+            element.click.returns(Promise.resolve());
+
+            const promise = actor.attemptsTo(
+                Check.whether(false)
+                    .andIfSo(
+                        Enter.theValue('Yay!').into(inputField),
+                        Enter.theValue('Yay!').into(inputField),
+                        Enter.theValue('Yay!').into(inputField))
+                    .otherwise(
+                        Enter.theValue('Noooo :-(').into(inputField),
+                        Enter.theValue('Noooo :-(').into(inputField),
+                        Enter.theValue('Noooo :-(').into(inputField)),
+            );
+
+            return expect(promise).to.be.eventually.fulfilled.then(() => {
+                expect(element.sendKeys).to.have.been.calledWith('Noooo :-(').callCount(3);
+            });
+
+        });
+    });
+    describe('when used with question argument returning a boolean', () => {
+        const inputField = Target.the('Input field').located(webdriver.By.css('button#wahoo'));
+
+        class MyBooleanQuestion implements Question<boolean> {
+            static withValue = (someValue: boolean) => new MyBooleanQuestion(someValue);
+            answeredBy = (actor: UsesAbilities) => this.value;
+            toString = () => 'My boolean question';
+
+            constructor(private value: boolean) {
+            }
+        }
+
+        it('triggers tasks in the andIfSo() argument when the question returns true', () => {
+            const
+                element = sinon.createStubInstance(webdriver.WebElement) as any,
+                actor = Actor.named('Nick').whoCan(BrowseTheWeb.using(fakeBrowserLocating(element)));
+
+            element.click.returns(Promise.resolve());
+
+            const promise = actor.attemptsTo(
+                Check.whetherQuestionTrue(MyBooleanQuestion.withValue(true))
+                    .andIfSo(
+                        Enter.theValue('Yay!').into(inputField),
+                        Enter.theValue('Yay!').into(inputField),
+                        Enter.theValue('Yay!').into(inputField))
+                    .otherwise(
+                        Enter.theValue('Noooo :-(').into(inputField),
+                        Enter.theValue('Noooo :-(').into(inputField),
+                        Enter.theValue('Noooo :-(').into(inputField)),
+            );
+
+            return expect(promise).to.be.eventually.fulfilled.then(() => {
+                expect(element.sendKeys).to.have.been.calledWith('Yay!').callCount(3);
+            });
+
+        });
+
+        it('triggers tasks in the otherwise() argument when the question returns false', () => {
+            const
+                element = sinon.createStubInstance(webdriver.WebElement) as any,
+                actor = Actor.named('Nick').whoCan(BrowseTheWeb.using(fakeBrowserLocating(element)));
+
+            element.click.returns(Promise.resolve());
+
+            const promise = actor.attemptsTo(
+                Check.whetherQuestionTrue(MyBooleanQuestion.withValue(false))
+                    .andIfSo(
+                        Enter.theValue('Yay!').into(inputField),
+                        Enter.theValue('Yay!').into(inputField),
+                        Enter.theValue('Yay!').into(inputField))
+                    .otherwise(
+                        Enter.theValue('Noooo :-(').into(inputField),
+                        Enter.theValue('Noooo :-(').into(inputField),
+                        Enter.theValue('Noooo :-(').into(inputField)),
+            );
+
+            return expect(promise).to.be.eventually.fulfilled.then(() => {
+                expect(element.sendKeys).to.have.been.calledWith('Noooo :-(').callCount(3);
+            });
+
+        });
+    });
+    describe('when used with question argument returning a boolean promise', () => {
+        const inputField = Target.the('Input field').located(webdriver.By.css('button#wahoo'));
+
+        class MyBooleanPromiseQuestion implements Question<PromiseLike<boolean>> {
+            static withValue = (someValue: boolean) => new MyBooleanPromiseQuestion(someValue);
+            answeredBy = (actor: UsesAbilities) => Promise.resolve(this.value);
+            toString = () => 'My boolean promise question';
+
+            constructor(private value: boolean) {
+            }
+        }
+
+        it('triggers tasks in the andIfSo() argument when the question returns a promise resolving a true value', () => {
+            const
+                element = sinon.createStubInstance(webdriver.WebElement) as any,
+                actor = Actor.named('Nick').whoCan(BrowseTheWeb.using(fakeBrowserLocating(element)));
+
+            element.click.returns(Promise.resolve());
+
+            const promise = actor.attemptsTo(
+                Check.whetherPromiseTrue(MyBooleanPromiseQuestion.withValue(true))
+                    .andIfSo(
+                        Enter.theValue('Yay!').into(inputField),
+                        Enter.theValue('Yay!').into(inputField),
+                        Enter.theValue('Yay!').into(inputField))
+                    .otherwise(
+                        Enter.theValue('Noooo :-(').into(inputField),
+                        Enter.theValue('Noooo :-(').into(inputField),
+                        Enter.theValue('Noooo :-(').into(inputField)),
+            );
+
+            return expect(promise).to.be.eventually.fulfilled.then(() => {
+                expect(element.sendKeys).to.have.been.calledWith('Yay!').callCount(3);
+            });
+
+        });
+
+        it('triggers tasks in the otherwise() argument when the question returns a promise resolving a false value', () => {
+            const
+                element = sinon.createStubInstance(webdriver.WebElement) as any,
+                actor = Actor.named('Nick').whoCan(BrowseTheWeb.using(fakeBrowserLocating(element)));
+
+            element.click.returns(Promise.resolve());
+
+            const promise = actor.attemptsTo(
+                Check.whetherPromiseTrue(MyBooleanPromiseQuestion.withValue(false))
+                    .andIfSo(
+                        Enter.theValue('Yay!').into(inputField),
+                        Enter.theValue('Yay!').into(inputField),
+                        Enter.theValue('Yay!').into(inputField))
+                    .otherwise(
+                        Enter.theValue('Noooo :-(').into(inputField),
+                        Enter.theValue('Noooo :-(').into(inputField),
+                        Enter.theValue('Noooo :-(').into(inputField)),
+            );
+
+            return expect(promise).to.be.eventually.fulfilled.then(() => {
+                expect(element.sendKeys).to.have.been.calledWith('Noooo :-(').callCount(3);
+            });
+
+        });
+    });
+});


### PR DESCRIPTION
Here's the specs and code to permit the following kinds of conditional flow control:

- `Check.whether(boolean).andIfSo(...).otherwise(...)`
- `Check.whetherQuestionTrue(Question<boolean>).andIfSo(...).otherwise(...)`
- `Check.whetherPromiseTrue(Question<PromiseLike<boolean>>).andIfSo(...).otherwise(...)`

Actually - I wanted the api to be `Check.whether()` for all constructor arguments for consistency with the java api, but couldn't find a way to overload the different types. Can you suggest a tweak for this please @jan-molak ?