### PR TITLE
#160 feat: add WaitForQuestion to ActiveWait

### DIFF
--- a/packages/serenity-js/spec/cookbook/waiting.recipe.ts
+++ b/packages/serenity-js/spec/cookbook/waiting.recipe.ts
@@ -19,19 +19,21 @@ import {
     WebElement,
 } from '../../src/screenplay-protractor';
 
+import { UsesAbilities } from '../../../core/lib/screenplay/actor';
+import { Question } from '../../../core/src/screenplay/question';
 import { AppServer } from '../support/server';
 
 export class Playground {
-    static Examples       = Target.the('example type').located(by.id('example_type'));
-    static Timeout_Type        = Target.the('timeout function type').located(by.id('timeout_type'));
-    static Timeout_Length      = Target.the('timeout length').located(by.id('timeout_length'));
+    static Examples = Target.the('example type').located(by.id('example_type'));
+    static Timeout_Type = Target.the('timeout function type').located(by.id('timeout_type'));
+    static Timeout_Length = Target.the('timeout length').located(by.id('timeout_length'));
     static Trigger = Target.the('trigger button').located(by.css('#timeouts button'));
-    static Result  = Target.the('result').located(by.css('#timeouts #example .result'));
+    static Result = Target.the('result').located(by.css('#timeouts #example .result'));
 }
 
 class ChooseAnExample implements Task {
     private timeout_length = Duration.ofMillis(500);
-    private timeout_type   = '$timeout' ;
+    private timeout_type = '$timeout';
 
     static whereElementBecomes = (example: string) => new ChooseAnExample(example);
 
@@ -59,16 +61,18 @@ class ChooseAnExample implements Task {
     }
 }
 
-describe ('When waiting for things to happen, a test scenario', function() {
+describe('When waiting for things to happen, a test scenario', function() {
 
     this.timeout(10000);
 
-    const Trigger_Delay   = Duration.ofMillis(2000),
-          Not_Long_Enough = Duration.ofMillis(500),
-          Long_Enough     = Duration.ofMillis(4000);
+    const Trigger_Delay = Duration.ofMillis(2000),
+        No_Delay = Duration.ofMillis(0),
+        Tiny_Delay = Duration.ofMillis(50),
+        Not_Long_Enough = Duration.ofMillis(500),
+        Long_Enough = Duration.ofMillis(4000);
 
     const
-        app   = new AppServer(),
+        app = new AppServer(),
         james = Actor.named('James').whoCan(BrowseTheWeb.using(protractor.browser));
 
     before(app.start());
@@ -78,9 +82,7 @@ describe ('When waiting for things to happen, a test scenario', function() {
 
         james.attemptsTo(
             Open.browserOn(app.demonstrating('waiting')),
-        ).
-
-        then(() => expect(james.toSee(WebElement.of(Playground.Result))).not.displayed));
+        ).then(() => expect(james.toSee(WebElement.of(Playground.Result))).not.displayed));
 
     [
         'setTimeout',
@@ -90,23 +92,19 @@ describe ('When waiting for things to happen, a test scenario', function() {
 
         describe(`using Passive Wait (${ timeoutFunction })`, () => {
 
-            it ('will fail if the timeout is too short', () =>
+            it('will fail if the timeout is too short', () =>
 
                 james.attemptsTo(
                     ChooseAnExample.whereElementBecomes('Visible').after(Trigger_Delay).using(timeoutFunction),
                     Wait.for(Not_Long_Enough),
-                ).
+                ).then(() => expect(james.toSee(WebElement.of(Playground.Result))).not.displayed));
 
-                then(() => expect(james.toSee(WebElement.of(Playground.Result))).not.displayed));
-
-            it ('will pass if the timeout is long enough', () =>
+            it('will pass if the timeout is long enough', () =>
 
                 james.attemptsTo(
                     ChooseAnExample.whereElementBecomes('Visible').after(Trigger_Delay).using(timeoutFunction),
                     Wait.for(Long_Enough),
-                ).
-
-                then(() => expect(james.toSee(WebElement.of(Playground.Result))).displayed));
+                ).then(() => expect(james.toSee(WebElement.of(Playground.Result))).displayed));
         });
 
         describe(`using Active Wait (${ timeoutFunction })`, () => {
@@ -132,9 +130,7 @@ describe ('When waiting for things to happen, a test scenario', function() {
                     expect(james.attemptsTo(
                         ChooseAnExample.whereElementBecomes('Visible').after(Trigger_Delay).using(timeoutFunction),
                         Wait.upTo(Long_Enough).until(Playground.Result, Is.visible()),
-                    )).to.be.fulfilled.
-
-                    then(() => Promise.all([
+                    )).to.be.fulfilled.then(() => Promise.all([
                         expect(james.toSee(WebElement.of(Playground.Result))).displayed,
                         expect(james.toSee(WebElement.of(Playground.Result))).present,
                     ])));
@@ -154,9 +150,7 @@ describe ('When waiting for things to happen, a test scenario', function() {
                     expect(james.attemptsTo(
                         ChooseAnExample.whereElementBecomes('Invisible').after(Trigger_Delay).using(timeoutFunction),
                         Wait.upTo(Long_Enough).until(Playground.Result, Is.invisible()),
-                    )).to.be.fulfilled.
-
-                    then(() => Promise.all([
+                    )).to.be.fulfilled.then(() => Promise.all([
                         expect(james.toSee(WebElement.of(Playground.Result))).not.displayed,
                         expect(james.toSee(WebElement.of(Playground.Result))).present,
                     ])));
@@ -176,9 +170,7 @@ describe ('When waiting for things to happen, a test scenario', function() {
                     expect(james.attemptsTo(
                         ChooseAnExample.whereElementBecomes('Present').after(Trigger_Delay).using(timeoutFunction),
                         Wait.upTo(Long_Enough).until(Playground.Result, Is.present()),
-                    )).to.be.fulfilled.
-
-                    then(() => Promise.all([
+                    )).to.be.fulfilled.then(() => Promise.all([
                         expect(james.toSee(WebElement.of(Playground.Result))).displayed,
                         expect(james.toSee(WebElement.of(Playground.Result))).present,
                     ])));
@@ -198,9 +190,7 @@ describe ('When waiting for things to happen, a test scenario', function() {
                     expect(james.attemptsTo(
                         ChooseAnExample.whereElementBecomes('Absent').after(Trigger_Delay).using(timeoutFunction),
                         Wait.upTo(Long_Enough).until(Playground.Result, Is.absent()),
-                    )).to.be.fulfilled.
-
-                    then(() => Promise.all([
+                    )).to.be.fulfilled.then(() => Promise.all([
                         expect(james.toSee(WebElement.of(Playground.Result))).not.present,
                     ])));
             });
@@ -219,9 +209,7 @@ describe ('When waiting for things to happen, a test scenario', function() {
                     expect(james.attemptsTo(
                         ChooseAnExample.whereElementBecomes('Selected').after(Trigger_Delay).using(timeoutFunction),
                         Wait.upTo(Long_Enough).until(Playground.Result, Is.selected()),
-                    )).to.be.fulfilled.
-
-                    then(() => Promise.all([
+                    )).to.be.fulfilled.then(() => Promise.all([
                         expect(james.toSee(WebElement.of(Playground.Result))).present,
                         expect(james.toSee(WebElement.of(Playground.Result))).displayed,
                         expect(james.toSee(WebElement.of(Playground.Result))).selected,
@@ -242,12 +230,34 @@ describe ('When waiting for things to happen, a test scenario', function() {
                     expect(james.attemptsTo(
                         ChooseAnExample.whereElementBecomes('Clickable').after(Trigger_Delay).using(timeoutFunction),
                         Wait.upTo(Long_Enough).until(Playground.Result, Is.clickable()),
-                    )).to.be.fulfilled.
-
-                    then(() => Promise.all([
+                    )).to.be.fulfilled.then(() => Promise.all([
                         expect(james.toSee(WebElement.of(Playground.Result))).present,
                         expect(james.toSee(WebElement.of(Playground.Result))).displayed,
                     ])));
+            });
+
+            describe('to determine if an question based wait', () => {
+
+                class MyBooleanPromiseQuestion implements Question<PromiseLike<boolean>> {
+                    static withValue = (someValue: boolean) => new MyBooleanPromiseQuestion(someValue);
+                    answeredBy = (actor: UsesAbilities) => Promise.resolve(this.value);
+                    toString = () => 'My boolean promise question';
+
+                    constructor(private value: boolean) {
+                    }
+                }
+
+                it('will fail if the question returns a false value during wait', () =>
+
+                    expect(james.attemptsTo(
+                        Wait.upTo(Tiny_Delay).untilQuestionAnsweredTrue(MyBooleanPromiseQuestion.withValue(false)),
+                    )).to.be.rejectedWith(/^My boolean promise question failed to return true answer within timeout period\nWait timed out after (.*)ms$/));
+
+                it('will pass if the question returns a true value during wait', () =>
+
+                    expect(james.attemptsTo(
+                        Wait.upTo(Tiny_Delay).untilQuestionAnsweredTrue(MyBooleanPromiseQuestion.withValue(true)),
+                    )).to.be.fulfilled);
             });
         });
     });

--- a/packages/serenity-js/src/serenity-protractor/screenplay/interactions/wait.ts
+++ b/packages/serenity-js/src/serenity-protractor/screenplay/interactions/wait.ts
@@ -4,10 +4,12 @@ import { BrowseTheWeb } from '../abilities/browse_the_web';
 import { Target } from '../ui/target';
 
 import { ElementFinder, protractor } from 'protractor';
+import { Question } from '../../../../../core/src/screenplay/question';
+import { WaitForQuestion } from './waitForQuestion';
 
 export class Duration {
-    static ofMillis  = (milliseconds: number) => new Duration(milliseconds);
-    static ofSeconds = (seconds: number)      => Duration.ofMillis(seconds * 1000);
+    static ofMillis = (milliseconds: number) => new Duration(milliseconds);
+    static ofSeconds = (seconds: number) => Duration.ofMillis(seconds * 1000);
 
     toMillis = () => this.milliseconds;
     toString = () => `${ this.milliseconds }ms`;
@@ -19,8 +21,9 @@ export class Duration {
 export type SuccessCondition<T> = (subject: T, timeout: Duration) => Activity;
 
 export class Wait {
-    static for   = (duration: Duration): Interaction => new PassiveWait(duration);
-    static upTo  = (timeout: Duration) => new ActiveWait(timeout);
+    static for = (duration: Duration): Interaction => new PassiveWait(duration);
+    static upTo = (timeout: Duration) => new ActiveWait(timeout);
+
     static until<T>(somethingToWaitFor: T, condition: SuccessCondition<T>) {
         return new ActiveWait().until(somethingToWaitFor, condition);
     }
@@ -33,19 +36,23 @@ export class ActiveWait {
         return condition(somethingToWaitFor, this.timeout);
     }
 
+    untilQuestionAnsweredTrue(question: Question<PromiseLike<boolean>>): WaitForQuestion {
+        return new WaitForQuestion(question, this.timeout);
+    }
+
     constructor(private timeout: Duration = ActiveWait.Default_Timeout) {
     }
 }
 
 export class Is {
-    static visible    = () => Is.aTargetThat(new IsVisible());
-    static invisible  = () => Is.aTargetThat(new IsInvisible());
-    static present    = () => Is.aTargetThat(new IsPresent());
-    static absent     = () => Is.aTargetThat(new Absent());
-    static selected   = () => Is.aTargetThat(new IsSelected());
-    static clickable  = () => Is.aTargetThat(new IsClickable());
+    static visible = () => Is.aTargetThat(new IsVisible());
+    static invisible = () => Is.aTargetThat(new IsInvisible());
+    static present = () => Is.aTargetThat(new IsPresent());
+    static absent = () => Is.aTargetThat(new Absent());
+    static selected = () => Is.aTargetThat(new IsSelected());
+    static clickable = () => Is.aTargetThat(new IsClickable());
 
-    private static aTargetThat(condition: Condition<ElementFinder>): SuccessCondition<Target>{
+    private static aTargetThat(condition: Condition<ElementFinder>): SuccessCondition<Target> {
         return (target: Target, timeout: Duration) => new WaitUntil(target, condition, timeout);
     }
 }
@@ -66,32 +73,32 @@ interface Condition<T> {
 
 class IsVisible implements Condition<ElementFinder> {
     check = (thing: ElementFinder): Function => protractor.ExpectedConditions.visibilityOf(thing);
-    name  = () => 'visible';
+    name = () => 'visible';
 }
 
 class IsInvisible implements Condition<ElementFinder> {
     check = (thing: ElementFinder): Function => protractor.ExpectedConditions.invisibilityOf(thing);
-    name  = () => 'invisible';
+    name = () => 'invisible';
 }
 
 class IsPresent implements Condition<ElementFinder> {
     check = (thing: ElementFinder): Function => protractor.ExpectedConditions.presenceOf(thing);
-    name  = () => 'present';
+    name = () => 'present';
 }
 
 class Absent implements Condition<ElementFinder> {
     check = (thing: ElementFinder): Function => protractor.ExpectedConditions.stalenessOf(thing);
-    name  = () => 'absent';
+    name = () => 'absent';
 }
 
 class IsSelected implements Condition<ElementFinder> {
     check = (thing: ElementFinder): Function => protractor.ExpectedConditions.elementToBeSelected(thing);
-    name  = () => 'selected';
+    name = () => 'selected';
 }
 
 class IsClickable implements Condition<ElementFinder> {
     check = (thing: ElementFinder): Function => protractor.ExpectedConditions.elementToBeClickable(thing);
-    name  = () => 'clickable';
+    name = () => 'clickable';
 }
 
 class WaitUntil implements Interaction {

--- a/packages/serenity-js/src/serenity-protractor/screenplay/interactions/waitForQuestion.ts
+++ b/packages/serenity-js/src/serenity-protractor/screenplay/interactions/waitForQuestion.ts
@@ -1,0 +1,33 @@
+import { until, WebDriver } from 'selenium-webdriver';
+import { BrowseTheWeb } from '../abilities/browse_the_web';
+import Condition = until.Condition;
+import { Interaction, Question, UsesAbilities } from '@serenity-js/core/lib/screenplay';
+import { Duration } from './wait';
+
+export class WaitForQuestion implements Interaction {
+
+    performAs(actor: UsesAbilities): PromiseLike<void> {
+        return BrowseTheWeb.as(actor).wait(() =>
+                this.question.answeredBy(actor).then(result => {
+                    return result;
+                }, (error: Error) => {
+                    if (error.name === 'StaleElementReferenceError') {
+                        // this happens a lot when question is being asked against a changing page, so return false and wait for next time.
+                        // tslint:disable-next-line:no-console
+                        console.warn(`[WaitForQuestion] handling error: ${error.name}`);
+                        return false;
+                    } else {
+                        throw error;
+                    }
+                }),
+            this.timeout.toMillis(),
+            `${ this.question } failed to return true answer within timeout period`,
+        );
+    }
+
+    toString = () => `{0} waits for ${ this.question }`;
+
+    constructor(private question: Question<PromiseLike<boolean>>, private timeout: Duration) {
+    }
+
+}


### PR DESCRIPTION
Hey @jan-molak I've added `WaitForQuestion` in order to provide further waiting flexibility outside of waiting for an ElementFinder Condition to be met (which as I understand is focussed on a the state of a single element). In my project I found myself wanting to wait for more sophisticated conditions that lean on the parsing/transformation/aggregation that can only really be done in a `Question`. 

So this pull request now allows you to do this kind of thing:
`Wait.upTo(<duration>).untilQuestionAnsweredTrue(<boolean Promise returning Question>)`