### PR TITLE
updated documentation

### DIFF
--- a/book/mocha/readme.md
+++ b/book/mocha/readme.md
@@ -7,3 +7,6 @@
 Mocha's lightweight syntax and excellent support for executing asynchronous test scenarios,
 combined with the power of Serenity/JS, make it a good choice for writing functional acceptance tests
 that drive the development of new systems or provide a safety net around the legacy ones.
+
+Especially it's great for highly technical teams, where everyone interested in contributing to the acceptance tests 
+is comfortable with basic software development.

--- a/book/overview/configuration.md
+++ b/book/overview/configuration.md
@@ -64,7 +64,7 @@ also (see [mixed mode](#mixed-mode)):
     }
 ```
 
-Learn more about [writing and executing test scenarios with Cucumber](./cucumber.md).
+Learn more about [writing and executing test scenarios with Cucumber](../cucumber).
 
 ## Mocha
 
@@ -122,7 +122,7 @@ exports.config = {
 }
 ```
 
-Learn more about [writing and executing test scenarios using Cucumber](./cucumber.md).
+Learn more about [writing and executing test scenarios using Mocha](../mocha).
 
 ## Serenity/JS - dialect
 

--- a/book/overview/configuration.md
+++ b/book/overview/configuration.md
@@ -292,7 +292,7 @@ What this means is that Cucumber can use step definitions and Mocha can execute 
 in TypeScript and some in JavaScript, yet they can still co-exist in the same codebase without a problem.
 
 This fact is incredibly useful when introducing Serenity/JS and TypeScript to an existing JavaScript codebase,
-because it allows for gradual and safe adoption of Serenity/JS, rather tha a big-bang re-write.
+because it allows for gradual and safe adoption of Serenity/JS, rather than a big-bang re-write.
 
 # TypeScript
 

--- a/book/overview/mocha.md
+++ b/book/overview/mocha.md
@@ -1,5 +1,0 @@
-great for highly technical teams, where everyone interested in contributing to the acceptance tests is 
-comfortable with basic software development
-
-
-{% include "../feedback.md" %}

--- a/book/overview/retrofitting.md
+++ b/book/overview/retrofitting.md
@@ -36,7 +36,7 @@ exports.config = {
 ```
 
 Serenity/JS detects whether to use Cucumber or Mocha based on the presence 
-of [`cucumberOpts`](../cucumber/readme.md) 
+of [`cucumberOpts`](./configuration.md#cucumber) 
 or [`mochaOpts`](mocha.md), respectively.
 If you prefer, you can tell Serenity/JS which test framework you'd like to use explicitly too:
 

--- a/book/overview/retrofitting.md
+++ b/book/overview/retrofitting.md
@@ -36,7 +36,7 @@ exports.config = {
 ```
 
 Serenity/JS detects whether to use Cucumber or Mocha based on the presence 
-of [`cucumberOpts`](cucumber.md) 
+of [`cucumberOpts`](../cucumber/readme.md) 
 or [`mochaOpts`](mocha.md), respectively.
 If you prefer, you can tell Serenity/JS which test framework you'd like to use explicitly too:
 
@@ -56,7 +56,7 @@ That's it! You can execute your tests the same way you used to.
 
 Now you can learn more about the [configuration options](./configuration.md) supported by 
 [`serenity-mocha`](mocha.md) and 
-[`serenity-cucumber`](cucumber.md) adapters and
+[`serenity-cucumber`](../cucumber/readme.md) adapters and
 running the tests using their respective test frameworks, or [configure the reporting](reporting.md) to convert
 the intermediary JSON reports produced by `serenity-js` to HTML.
  

--- a/book/overview/retrofitting.md
+++ b/book/overview/retrofitting.md
@@ -37,7 +37,7 @@ exports.config = {
 
 Serenity/JS detects whether to use Cucumber or Mocha based on the presence 
 of [`cucumberOpts`](./configuration.md#cucumber) 
-or [`mochaOpts`](mocha.md), respectively.
+or [`mochaOpts`](./configuration.md#mocha), respectively.
 If you prefer, you can tell Serenity/JS which test framework you'd like to use explicitly too:
 
 ```javascript
@@ -55,7 +55,7 @@ exports.config = {
 That's it! You can execute your tests the same way you used to.
 
 Now you can learn more about the [configuration options](./configuration.md) supported by 
-[`serenity-mocha`](mocha.md) and 
+[`serenity-mocha`](../mocha/readme.md) and 
 [`serenity-cucumber`](../cucumber/readme.md) adapters and
 running the tests using their respective test frameworks, or [configure the reporting](reporting.md) to convert
 the intermediary JSON reports produced by `serenity-js` to HTML.


### PR DESCRIPTION
Fixed broken links in retrofitting.html
The page http://serenity-js.org/overview/retrofitting.html had four non working links:
1. cucumberOpts
2. mochaOpts
3. serenity-mocha
4. serenity-cucumber

Fixed broken link, fixed copy&paste mistyping in overview/configuration.md.