### PR TITLE
#369: feat - add support for alerts into Serenity-js 2.0

### DIFF
--- a/packages/protractor/spec/expectations/alertIsPresent.spec.ts
+++ b/packages/protractor/spec/expectations/alertIsPresent.spec.ts
@@ -1,0 +1,31 @@
+import { expect, stage } from '@integration/testing-tools';
+import { Ensure, equals} from '@serenity-js/assertions';
+import { Alert, Accept, Click, Dismiss, Navigate, Text, Wait } from '../../src';
+import { alertTargets, pageFromTemplate, pageWithAlerts } from '../fixtures';
+import { UIActors } from '../UIActors';
+
+describe('When demonstrating how to work with alert windows, an actor', function () {
+
+    const Nick = stage(new UIActors()).actor('Nick');
+
+    beforeEach(() => Nick.attemptsTo(
+        Navigate.to(pageFromTemplate(pageWithAlerts)),
+    ));
+
+    /** @test {Accept alert} */
+    it('can click the OK action of a triggered alert and see the alert accepted', () => expect(Nick.attemptsTo(
+        Click.on(alertTargets.trigger),
+        Wait.until(Alert.visibility(), equals(true)),
+        Accept.alert(),
+        Ensure.that(Text.of(alertTargets.textResult), equals('You pressed OK!')),
+    )).to.be.fulfilled);
+
+    /** @test {Dismiss alert} */
+    it('can click the cancel action of a triggered alert and see the alert dismissed', () => expect(Nick.attemptsTo(
+        Click.on(alertTargets.trigger),
+        Wait.until(Alert.visibility(), equals(true)),
+        Dismiss.alert(),
+        Ensure.that(Text.of(alertTargets.textResult), equals('You pressed OK!')),
+    )).to.be.fulfilled);
+
+});

--- a/packages/protractor/spec/fixtures.ts
+++ b/packages/protractor/spec/fixtures.ts
@@ -1,4 +1,6 @@
 import { minify } from 'html-minifier';
+import { Target } from '../src/screenplay/questions/targets';
+import { by } from 'protractor';
 
 export function pageFromTemplate(template: string): string {
     return `data:text/html;charset=utf-8,${ minify(`<!DOCTYPE html>${ template }`, {
@@ -8,3 +10,32 @@ export function pageFromTemplate(template: string): string {
         keepClosingSlash: true,
     }) }`;
 }
+
+export const alertTargets = {
+    trigger: Target.the('alert trigger').located(by.id('alert-demo-trigger')),
+    textResult: Target.the('text of the alert clicking result').located(by.id('alert-demo-result'))
+};
+
+export const pageWithAlerts = `
+    <!DOCTYPE html>
+        <html>
+            <body>
+                <p>Test page for <a href="./Alert.spec.ts">alert visibility unit test</a></p>
+                <button id="alert-demo-trigger" onclick="myFunction()">Trigger Alert</button>
+                <p id="alert-demo-result"></p>
+                <script>
+                    function myFunction() {
+                        var resultText;
+                        var response = confirm("Press OK or Cancel");
+                        if (response) {
+                            resultText = "You pressed OK!";
+                        } else {
+                            resultText = "You pressed Cancel!";
+                        }
+                        document.getElementById("alert-demo-result").innerHTML = resultText;
+                    }
+                </script>
+            
+            </body>
+        </html>
+`;

--- a/packages/protractor/spec/screenplay/questions/Alert.spec.ts
+++ b/packages/protractor/spec/screenplay/questions/Alert.spec.ts
@@ -1,0 +1,27 @@
+import { stage } from '@integration/testing-tools';
+import { Ensure, equals } from '@serenity-js/assertions';
+import { Alert } from '../../../src/screenplay/questions';
+import { alertTargets, pageFromTemplate, pageWithAlerts } from '../../fixtures';
+import { UIActors } from '../../UIActors';
+import { Click, Navigate } from '../../../src/screenplay/interactions';
+
+describe('Alert', () => {
+
+    const Nick = stage(new UIActors()).actor('Nick');
+
+    /** @test {Attribute} */
+    it('allows the actor to determine that alert visibility is false', () => Nick.attemptsTo(
+        Navigate.to(pageFromTemplate(`
+        <html lang="en" />
+    `)),
+        Ensure.that(Alert.visibility(), equals(false)),
+    ));
+
+    it('allows the actor to determine that alert visibility is false', () => Nick.attemptsTo(
+        Navigate.to(pageFromTemplate(pageWithAlerts)),
+        Click.on(alertTargets.trigger),
+        Ensure.that(Alert.visibility(), equals(true)),
+    ));
+
+
+});

--- a/packages/protractor/src/screenplay/abilities/BrowseTheWeb.ts
+++ b/packages/protractor/src/screenplay/abilities/BrowseTheWeb.ts
@@ -1,6 +1,6 @@
 import { Ability, LogicError, UsesAbilities } from '@serenity-js/core';
 import { ActionSequence, ElementArrayFinder, ElementFinder, Locator, protractor, ProtractorBrowser } from 'protractor';
-import { Capabilities, Navigation, Options } from 'selenium-webdriver';
+import { AlertPromise, Capabilities, Navigation, Options } from 'selenium-webdriver';
 import { promiseOf } from '../../promiseOf';
 
 /**
@@ -341,6 +341,36 @@ export class BrowseTheWeb implements Ability {
 
     /**
      * @desc
+     *  Switch the browser to an alert if there is one.
+     *
+     * @returns {AlertPromise}
+     */
+    switchToAlert(): AlertPromise {
+        return this.browser.switchTo().alert();
+    }
+
+    /**
+     * @desc
+     *  Accept an active alert.
+     *
+     * @returns {Promise<void>}
+     */
+    acceptAlert(): PromiseLike<void> {
+        return this.switchToAlert().accept();
+    }
+
+    /**
+     * @desc
+     *  Dismiss an active alert.
+     *
+     * @returns {Promise<void>}
+     */
+    dismissAlert(): PromiseLike<void> {
+        return this.switchToAlert().dismiss();
+    }
+
+    /**
+     * @desc
      *  Pause the actor flow until the condition is met or the timeout expires.
      *
      * @returns {Promise<boolean>}
@@ -350,7 +380,7 @@ export class BrowseTheWeb implements Ability {
     }
 
     getLastScriptExecutionResult(): any {
-        if (! this.lastScriptExecutionSummary) {
+        if (!this.lastScriptExecutionSummary) {
             throw new LogicError(`Make sure to execute a script before checking on the result`);
         }
 
@@ -362,5 +392,6 @@ export class BrowseTheWeb implements Ability {
  * @package
  */
 class LastScriptExecutionSummary {
-    constructor(public readonly result: any) {}
+    constructor(public readonly result: any) {
+    }
 }

--- a/packages/protractor/src/screenplay/interactions/Accept.ts
+++ b/packages/protractor/src/screenplay/interactions/Accept.ts
@@ -1,0 +1,8 @@
+import { Interaction } from '@serenity-js/core/lib/screenplay';
+import { BrowseTheWeb } from '../abilities';
+
+export class Accept {
+    static alert = () => Interaction.where(`#actor accepts the alert popup`,
+        actor => BrowseTheWeb.as(actor).acceptAlert()
+    );
+}

--- a/packages/protractor/src/screenplay/interactions/Dismiss.ts
+++ b/packages/protractor/src/screenplay/interactions/Dismiss.ts
@@ -1,0 +1,8 @@
+import { Interaction } from '@serenity-js/core/lib/screenplay';
+import { BrowseTheWeb } from '../abilities';
+
+export class Dismiss {
+    static alert = () => Interaction.where(`#actor dismisses the alert popup`,
+        actor => BrowseTheWeb.as(actor).dismissAlert()
+    );
+}

--- a/packages/protractor/src/screenplay/interactions/index.ts
+++ b/packages/protractor/src/screenplay/interactions/index.ts
@@ -1,5 +1,7 @@
+export * from './Accept';
 export * from './Clear';
 export * from './Click';
+export * from './Dismiss';
 export * from './DeleteCookies';
 export * from './DoubleClick';
 export * from './Enter';

--- a/packages/protractor/src/screenplay/questions/Alert.ts
+++ b/packages/protractor/src/screenplay/questions/Alert.ts
@@ -1,0 +1,17 @@
+import { Question } from '@serenity-js/core';
+import { BrowseTheWeb } from '../abilities';
+
+export class Alert {
+    static visibility(): Question<boolean> {
+        return Question.about(`the visibility of an alert`, actor => {
+                try {
+                    BrowseTheWeb.as(actor).switchToAlert();
+                    return true;
+                } catch (e) {
+                    return false;
+                }
+            },
+        );
+    }
+
+}

--- a/packages/protractor/src/screenplay/questions/index.ts
+++ b/packages/protractor/src/screenplay/questions/index.ts
@@ -1,3 +1,4 @@
+export * from './Alert';
 export * from './Attribute';
 export * from './Browser';
 export * from './Cookie';


### PR DESCRIPTION
Hope I've done something along the right lines here Jan - feedback welcome 😄. I did have problem running the tests following `npm run verify` from top level project:

```
@integration/cucumber-2-runner: src/support/configure_serenity.ts(10,9): error TS2345: Argument of type 'ChildProcessReporter' is not assignable to parameter of type 'StageCrewMember'.
@integration/cucumber-2-runner:   Types of property 'assignedTo' are incompatible.
@integration/cucumber-2-runner:     Type '(stage: import("/Users/nick/dev/git-personal/serenity-js/integration/testing-tools/node_modules/@serenity-js/core/lib/stage/Stage").Stage) => import("serenity-js/integration/testing-tools/node_modules/@serenity-js/core/lib/stage/StageCrewMember").StageCrewMember' is not assignable to type '(stage: import("/Users/nick/dev/git-personal/serenity-js/packages/core/lib/stage/Stage").Stage) => import("/Users/nick/dev/git-personal/serenity-js/packages/core/lib/stage/StageCrewMember").StageCrewMember'.
@integration/cucumber-2-runner:       Types of parameters 'stage' and 'stage' are incompatible.
@integration/cucumber-2-runner:         Type 'import("/Users/nick/dev/git-personal/serenity-js/packages/core/lib/stage/Stage").Stage' is not assignable to type 'import("/Users/nick/dev/git-personal/serenity-js/integration/testing-tools/node_modules/@serenity-js/core/lib/stage/Stage").Stage'.
@integration/cucumber-2-runner:           Types have separate declarations of a private property 'dressingRoom'.

```
This looks like an incompatibility in the `integration/testing-tools` module which is not something I've changed? 

Note that the [travis build #870](https://travis-ci.org/jan-molak/serenity-js/builds/613765891?utm_source=github_status&utm_medium=notification) does not reflect the latest version of the PR as I've force pushed a few more commits in since the first as I make adjustments ...